### PR TITLE
change location on tab activate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/components/feature-tabs.js
+++ b/components/feature-tabs.js
@@ -14,13 +14,13 @@ class FeatureTabs extends BaseComponent {
                       window.location.href.indexOf("#ES5")>=0 ? 2 : 0);
     return (<div style={{'maxWidth': '1024', 'margin':'auto'}}>
         <Tabs initialSelectedIndex={tabIndex}>
-            <Tab label="ES7/ES2016" id="es7">
+            <Tab label="ES7/ES2016" id="es7" onActive={() => window.location = '#ES7'}>
                 <Feature spec='ES7' />
             </Tab>
-            <Tab label="ES6/ES2015" id="es6">
+            <Tab label="ES6/ES2015" id="es6" onActive={() => window.location = '#ES6'}>
                 <Feature spec='ES6' />
             </Tab>
-            <Tab label="ES5" id="es5">
+            <Tab label="ES5" id="es5" onActive={() => window.location = '#ES5'}>
                 <Feature spec='ES5' />
             </Tab>
         </Tabs>

--- a/components/feature-tabs.js
+++ b/components/feature-tabs.js
@@ -5,15 +5,34 @@ import mui, { Tab, Tabs } from 'material-ui';
 
 class FeatureTabs extends BaseComponent {
   constructor () {
-    super()
+    super();
+
+
+    this.state = {
+        tabIndex: this.getTabIndex()
+    };
+
+    window.addEventListener("hashchange", this.onHashChange.bind(this), false);
   }
-  render () {
+
+  onHashChange () {
+    this.setState({
+        tabIndex: this.getTabIndex()
+    });
+  }
+
+  getTabIndex () {
     // Till material-ui gives an option to update tabIndex programatically.
     const tabIndex = (window.location.href.indexOf("#ES7")>=0 ? 0 :
                       window.location.href.indexOf("#ES6")>=0 ? 1 :
                       window.location.href.indexOf("#ES5")>=0 ? 2 : 0);
+    return tabIndex;
+  }
+
+  render () {
+
     return (<div style={{'maxWidth': '1024', 'margin':'auto'}}>
-        <Tabs initialSelectedIndex={tabIndex}>
+        <Tabs initialSelectedIndex={this.state.tabIndex}>
             <Tab label="ES7/ES2016" id="es7" onActive={() => window.location = '#ES7'}>
                 <Feature spec='ES7' />
             </Tab>


### PR DESCRIPTION
How about setting the link to the tab on tab activate? React-router seams overkill and doesn't play nice with material-ui.
