### PR TITLE
Fix: wrong bower reference for prism-highlighter

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 
   <link rel="import" href="/src/my-app.html">
-  <link href="../bower_components/prism-element/prism-highlighter.html" rel="import">
+  <link href="/bower_components/prism-element/prism-highlighter.html" rel="import">
 
   <style>
 
@@ -68,6 +68,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <prism-highlighter></prism-highlighter>
   <my-app></my-app>
-
 </body>
 </html>


### PR DESCRIPTION
The import link for `prism-highlighter.html` was wrong. Fixed it
