### PR TITLE
Fixes for theme-color and color contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
   <title>JS features</title>
-  
+
   <link rel="shortcut icon" sizes="32x32" href="/images/app-icon-32.png">
-  <meta name="theme-color" content="#fff">
+  <meta name="theme-color" content="#4285f4">
   <link rel="manifest" href="/manifest.json">
 
   <script>

--- a/manifest.json
+++ b/manifest.json
@@ -48,10 +48,9 @@
       "type": "image\/png"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#fdd835",
+  "background_color": "#f0db4e",
   "display": "standalone",
   "start_url": "/",
   "short_name": "jsfeatures"
 }
-

--- a/src/es-features.html
+++ b/src/es-features.html
@@ -52,18 +52,20 @@
       .token.operator, .token.entity, .token.url, .language-css .token.string, .style .token.string {
           background-color: transparent;
       }
-      <style>
-        :host {
-          display: block;
-        }
-        .markdown-body {
-          box-sizing: border-box;
-          max-width: 980px;
-          min-width: 200px;
-          padding: 45px;
-          margin: 0 auto;
-        }
-      </style>
+      :host {
+        display: block;
+      }
+      .markdown-body {
+        box-sizing: border-box;
+        max-width: 980px;
+        min-width: 200px;
+        padding: 45px;
+        margin: 0 auto;
+      }
+
+      h2 {
+        color: #333;
+      }
     </style>
 
     <iron-ajax auto

--- a/src/js-features.html
+++ b/src/js-features.html
@@ -50,6 +50,9 @@
         padding-left: 32px;
       }
 
+      .jsfeatures-title {
+        margin-left: 10px;
+      }
 
     </style>
 
@@ -78,7 +81,7 @@
         <app-header condenses reveals effects="waterfall">
           <app-toolbar>
             <paper-icon-button icon="menu" drawer-toggle></paper-icon-button>
-            <div title>jsfeatures.in</div>
+            <div title class="jsfeatures-title">jsfeatures.in</div>
           </app-toolbar>
         </app-header>
 


### PR DESCRIPTION
_Done:_
1. Fixed theme-color which was #fff to same color as app header
2. Changed the heading color of app
3. Changed splash screen similar to logo

![screenshot_20160713-083351](https://cloud.githubusercontent.com/assets/2944237/16791912/e46d8a12-48e0-11e6-9d83-6f2d878d5af6.png)

![screenshot_20160713-095530](https://cloud.githubusercontent.com/assets/2944237/16791913/e470117e-48e0-11e6-9f54-f4c868a245ea.png)
